### PR TITLE
RSpec: use config.disable_monkey_patching!

### DIFF
--- a/spec/bitemporal_date_spec.rb
+++ b/spec/bitemporal_date_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Sequel::Plugins::Bitemporal" do
+RSpec.describe "Sequel::Plugins::Bitemporal" do
   before :all do
     db_setup
   end
@@ -791,7 +791,7 @@ describe "Sequel::Plugins::Bitemporal" do
   end
 end
 
-describe "Sequel::Plugins::Bitemporal", "with audit" do
+RSpec.describe "Sequel::Plugins::Bitemporal", "with audit" do
   before :all do
     @audit_class = Class.new do
       def self.audit(*args); end
@@ -889,7 +889,7 @@ describe "Sequel::Plugins::Bitemporal", "with audit" do
     end
   end
 end
-describe "Sequel::Plugins::Bitemporal", "with audit, specifying how to get the author" do
+RSpec.describe "Sequel::Plugins::Bitemporal", "with audit, specifying how to get the author" do
   before :all do
     @audit_class = Class.new do
       def self.audit(*args); end

--- a/spec/bitemporal_date_with_range_spec.rb
+++ b/spec/bitemporal_date_with_range_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 if DbHelpers.pg?
-  describe "Sequel::Plugins::Bitemporal", "with ranges" do
+  RSpec.describe "Sequel::Plugins::Bitemporal", "with ranges" do
     before :all do
       db_setup ranges: true
     end
@@ -637,7 +637,7 @@ if DbHelpers.pg?
     end
   end
 
-  describe "Sequel::Plugins::Bitemporal", "with audit and ranges" do
+  RSpec.describe "Sequel::Plugins::Bitemporal", "with audit and ranges" do
     before :all do
       @audit_class = Class.new do
         def self.audit(*args); end
@@ -735,7 +735,7 @@ if DbHelpers.pg?
       end
     end
   end
-  describe "Sequel::Plugins::Bitemporal", "with audit, ranges, specifying how to get the author" do
+  RSpec.describe "Sequel::Plugins::Bitemporal", "with audit, ranges, specifying how to get the author" do
     before :all do
       @audit_class = Class.new do
         def self.audit(*args); end

--- a/spec/bitemporal_serialization_spec.rb
+++ b/spec/bitemporal_serialization_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 require "json"
 
-describe "Sequel::Plugins::Bitemporal", :skip_jdbc_sqlite do
+RSpec.describe "Sequel::Plugins::Bitemporal", :skip_jdbc_sqlite do
   before :all do
     db_setup
     @version_class.instance_eval do

--- a/spec/bitemporal_time_spec.rb
+++ b/spec/bitemporal_time_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "Sequel::Plugins::Bitemporal" do
+RSpec.describe "Sequel::Plugins::Bitemporal" do
   let(:hour){ 3600 }
   before :all do
     db_setup use_time: true
@@ -381,7 +381,7 @@ describe "Sequel::Plugins::Bitemporal" do
     expect(@master_class.with_current_or_future_versions.all.size).to eq(2)
   end
 end
-describe "Sequel::Plugins::Bitemporal", "with audit" do
+RSpec.describe "Sequel::Plugins::Bitemporal", "with audit" do
   before :all do
     @audit_class = Class.new
     db_setup use_time: true, audit_class: @audit_class
@@ -435,7 +435,7 @@ describe "Sequel::Plugins::Bitemporal", "with audit" do
   end
 end
 
-describe "Sequel::Plugins::Bitemporal", "with audit, specifying how to get the author" do
+RSpec.describe "Sequel::Plugins::Bitemporal", "with audit, specifying how to get the author" do
   before :all do
     @audit_class = Class.new
     db_setup use_time: true, audit_class: @audit_class, audit_updated_by_method: :author

--- a/spec/bitemporal_time_with_range_spec.rb
+++ b/spec/bitemporal_time_with_range_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 if DbHelpers.pg?
-  describe "Sequel::Plugins::Bitemporal" do
+  RSpec.describe "Sequel::Plugins::Bitemporal" do
     let(:hour){ 3600 }
     before :all do
       db_setup use_time: true, ranges: true
@@ -381,7 +381,7 @@ if DbHelpers.pg?
       expect(@master_class.with_current_or_future_versions.all.size).to eq(2)
     end
   end
-  describe "Sequel::Plugins::Bitemporal", "with audit" do
+  RSpec.describe "Sequel::Plugins::Bitemporal", "with audit" do
     before :all do
       @audit_class = Class.new
       db_setup use_time: true, audit_class: @audit_class, ranges: true
@@ -435,7 +435,7 @@ if DbHelpers.pg?
     end
   end
 
-  describe "Sequel::Plugins::Bitemporal", "with audit, specifying how to get the author" do
+  RSpec.describe "Sequel::Plugins::Bitemporal", "with audit, specifying how to get the author" do
     before :all do
       @audit_class = Class.new
       db_setup(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,7 @@ end
 RSpec.configure do |config|
   config.include DbHelpers
   config.filter_run_excluding rspec_exclusions
+  config.disable_monkey_patching!
   config.before :each do
     db_truncate
   end


### PR DESCRIPTION
This PR introduces the use of RSpec's mode for "avoid adding `describe` to all Objects".

  - See https://relishapp.com/rspec/rspec-core/v/3-8/docs/configuration/zero-monkey-patching-mode